### PR TITLE
Apache License in default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,8 @@
 # Cookbook Name:: ssl
 # Recipe:: default
 #
+# Copyright 2011-2012 Venda Ltd
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,9 +2,17 @@
 # Cookbook Name:: ssl
 # Recipe:: default
 #
-# Copyright 2012, Venda Ltd
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# All rights reserved - Do Not Redistribute
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 include_recipe "gpg"


### PR DESCRIPTION
Hello there.  Excellent cookbook.

I noticed that the README listed the license as Apache 2.0, while the default recipe still said "do not distribute"
