### PR TITLE
Use Knife's builtin facility to configure chef.

### DIFF
--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -17,7 +17,12 @@ module ChefSSL
   class Client
 
     def initialize
-      Chef::Knife.new.configure_chef
+      Chef::Knife.new.tap do |knife|
+        # Set the log-level, knife style. This equals :error level
+        Chef::Config[:verbosity] = knife.config[:verbosity] ||= 0
+        knife.configure_chef
+      end
+
       Spice.reset
       Spice.setup do |s|
         s.server_url = Chef::Config.chef_server_url

--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'openssl'
 require 'digest/sha2'
 require 'active_support/hash_with_indifferent_access'
+require 'chef/knife'
 require 'chef/config'
 require 'chef/node'
 
@@ -16,8 +17,7 @@ module ChefSSL
   class Client
 
     def initialize
-      path = File.expand_path('knife.rb', '~/.chef')
-      Chef::Config.from_file(path)
+      Chef::Knife.new.configure_chef
       Spice.reset
       Spice.setup do |s|
         s.server_url = Chef::Config.chef_server_url


### PR DESCRIPTION
This allows to place the knife.rb in any of the supported locations, e.g. inside a chef repo.
