### PR TITLE
Allow to set a different common name from the name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ REST API Server Certificate, with CA Certificate:
 REST API Client Certificate:
 
     ssl_certificate "service-#{node['fqdn']}" do
+      cn node['fqdn']
       ca "Service-CA"
       type "client"
       key "/etc/service/client_key.pem"

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -73,7 +73,7 @@ action :create do
         # Generate the new CSR using the existing key
         csr = ssl_generate_csr(
           key,
-          :common_name => new_resource.name,
+          :common_name => new_resource.cn || new_resource.name,
           :city => node['ssl']['city'],
           :state => node['ssl']['state'],
           :email => node['ssl']['email'],
@@ -91,7 +91,7 @@ action :create do
         # Generate the CSR, and sign it with a scratch CA to create a
         # temporary certificate.
         csr = ssl_generate_csr(key,
-          :common_name => new_resource.name,
+          :common_name => new_resource.cn || new_resource.name,
           :city => node['ssl']['city'],
           :state => node['ssl']['state'],
           :email => node['ssl']['email'],

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -6,6 +6,7 @@ def initialize(*args)
 end
 
 attribute :name, :kind_of => String, :name_attribute => true
+attribute :cn,   :kind_of => String
 attribute :ca,   :kind_of => String, :required => true
 attribute :type, :kind_of => String, :default => 'server', :equal_to => ['server', 'client']
 attribute :bits, :kind_of => Fixnum, :default => 2048, :equal_to => [1024, 2048, 4096, 8192]


### PR DESCRIPTION
This is at least required if you want to create multiple certificates on the
same host for the same common name, e.g. on a message broker which has a
client and a server certificate.
