### PR TITLE
Allow to create a self-signed cert on Ruby 1.8

### DIFF
--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -23,7 +23,7 @@ def x509_issue_self_signed_cert(csr, type, name)
   # all the serial numbers are the same. some browsers will reject all
   # but the first with the same common name and serial, even if the
   # certificate is different.
-  rand = Base64.urlsafe_encode64(OpenSSL::Random.pseudo_bytes(12))
+  rand = urlsafe_encode64(OpenSSL::Random.pseudo_bytes(12))
   name[:common_name] = "Temporary CA #{rand}"
   ca = EaSSL::CertificateAuthority.new(:name => name)
   cert = EaSSL::Certificate.new(
@@ -39,4 +39,13 @@ def x509_verify_key_cert_match(key_text, cert_text)
   key = OpenSSL::PKey::RSA.new(key_text)
   cert = OpenSSL::X509::Certificate.new(cert_text)
   key.n == cert.public_key.n
+end
+
+def urlsafe_encode64(bin)
+  if Base64.respond_to?(:urlsafe_encode64)
+    # Only available in Ruby 1.9
+    Base64.urlsafe_encode64(bin)
+  else
+    [bin].pack("m0").chomp("\n").tr("+/", "-_")
+  end
 end


### PR DESCRIPTION
`Base64.urlsafe_encode64` is only available on Ruby 1.9. This pull request ensures that if we are on Ruby 1.8, we have an equivalent implementation available.

As an alternative you could just use `Base64.encode64`, which is available in 1.8 and 1.9 and as far as I have seen it should also work here. It creates a slightly different Base64 representation (RFC 4648 with URL and Filename Safe Alphabet vs. RFC 2045) but as we don't use the generated string anywhere in filenames or URLs, we should be safe here.
