### PR TITLE
Make keyvault optional, and disabled by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Attributes
 
 GPG is used to encrypt generated keys for archival purposes.
 
-`node['x509']['key_vault']` - the email address of the GPG/PGP key.
+`node['x509']['key_vault']` - the email address of the GPG/PGP recipient.
+
+When set to nil (the default), keys will not be archived.
 
 DN components to use when creating certificate names:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,8 @@
-default['x509']['key_vault'] = 'keyvault@example.com'
+# When set, the generated key will be GPG encrypted to this recipient,
+# and the encrypted copy stored in node data. eg:
+# default['x509']['key_vault'] = 'keyvault@example.com'
+#
+default['x509']['key_vault'] = nil
 
 default['x509']['country'] = 'GB'
 default['x509']['state'] = 'London'

--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -77,7 +77,12 @@ action :create do
       if ::File.size?(new_resource.key)
         # If we already have a private key, reuse it
         key = x509_load_key(new_resource.key)
-        encrypted_key = gpg_encrypt(key.private_key.to_s, node['x509']['key_vault'])
+
+        if node['x509']['key_vault']
+          encrypted_key = gpg_encrypt(key.private_key.to_s, node['x509']['key_vault'])
+        else
+          encrypted_key = nil
+        end
 
         # Generate the new CSR using the existing key
         csr = x509_generate_csr(
@@ -95,7 +100,12 @@ action :create do
         # Generate and encrypt the private key with the public key of
         # the key vault user.
         key = x509_generate_key(new_resource.bits)
-        encrypted_key = gpg_encrypt(key.private_key.to_s, node['x509']['key_vault'])
+
+        if node['x509']['key_vault']
+          encrypted_key = gpg_encrypt(key.private_key.to_s, node['x509']['key_vault'])
+        else
+          encrypted_key = nil
+        end
 
         # Generate the CSR, and sign it with a scratch CA to create a
         # temporary certificate.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe "vt-gpg"
+# We only need vt-gpg if we're using the keyvault
+if node['x509']['key_vault']
+  include_recipe "vt-gpg"
+end
 
 chef_gem "eassl2" do
   action :nothing


### PR DESCRIPTION
In some environments, the keys generated with this LWRP are not very
valuable.  If they are lost, generating new keys (and certs, and CSRs)
is okay.  Use of a key vault should be optional for such environments.

Disabling the key vault by default reduces the learning curve for new
users by making the vt-gpg cookbook an optional dependency.
