### PR TITLE
Quieten logging for x509_certificate resource

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -50,15 +50,14 @@ action :create do
       # (if not, maybe someone created the key+cert manually)
       if x509_verify_key_cert_match(::File.read(new_resource.key), certbag['certificate'])
         Chef::Log.info("installing certificate #{new_resource.name} (id #{cert_id})")
-        file new_resource.certificate do
-          content certbag['certificate']
-          action :create
-        end
+        f = resource("file[#{new_resource.certificate}]")
+        f.content certbag['certificate']
+        f.action :create
+        
         if new_resource.cacertificate && certbag['cacert']
-          file new_resource.cacertificate do
-            content certbag['cacert']
-            action :create
-          end
+          f = resource("file[#{new_resource.cacertificate}]")
+          f.content certbag['cacert']
+          f.action :create
         end
       else
         Chef::Log.warn("not installing certificate #{new_resource.name} (id #{cert_id}), does not match key")
@@ -133,27 +132,28 @@ action :create do
       }
 
       # write out the key
-      file new_resource.key do
-        content key.private_key.to_s
-        action :create
-      end
+      f = resource("file[#{new_resource.key}]")
+      f.content key.private_key.to_s
+      f.action :create
 
       # write out the cert if we created a temporary one
       unless cert.nil?
-        file new_resource.certificate do
-          content cert.to_pem
-          action :create
-        end
+        f = resource("file[#{new_resource.certificate}]")
+        f.content cert.to_pem
+        f.action :create
       end
 
       if new_resource.cacertificate && !ca.nil?
-        file new_resource.cacertificate do
-          content ca.certificate.to_pem
-          action :create
-        end
+        f = resource("file[#{new_resource.cacertificate}]")
+        f.content ca.certificate.to_pem
+        f.action :create
       end
 
       new_resource.updated_by_last_action(true)
     end
   end
+end
+
+def resource(name)
+  run_context.resource_collection.find(name)
 end

--- a/spec/providers/x509_certificate_spec.rb
+++ b/spec/providers/x509_certificate_spec.rb
@@ -8,7 +8,7 @@ describe 'x509_certificate', :type => :provider do
     search = flexmock('search') do |m|
       m.should_receive(:search).with_any_args()
     end
-    flexmock(Chef::Search::Query).should_receive(:new).and_return(search)
+    flexmock(Chef::Search::Query).should_receive(:new).and_return(search).by_default
     flexmock(Chef::DataBagItem).should_receive(:load)
       .and_raise(Net::HTTPServerException.new(1, 2)).by_default
     flexmock(GPGME::Crypto).should_receive(:new).
@@ -179,10 +179,14 @@ describe 'x509_certificate', :type => :provider do
     }
 
     it "should update certificate" do
-      flexmock(Chef::DataBagItem).should_receive(:load)
-        .and_return({
-          'certificate' => 'test-cert-text'
-        })
+      # Mocking search() looking for the certificate databag item
+      search_query = "id:729c42d574be013c27ee3600bd87018825792c9d15057d2b0b8833796aa09e19"
+      search = flexmock('search') do |m|
+        m.should_receive(:search)
+          .with(:certificates, search_query, FlexMock.any)
+          .and_yield( {'certificate' => 'test-cert-text'} )
+      end
+      flexmock(Chef::Search::Query).should_receive(:new).and_return(search)
 
       # mocking File.size for the specific files the provider
       # expects - here, the key exists
@@ -243,11 +247,17 @@ describe 'x509_certificate', :type => :provider do
     }
 
     it "should update certificate and install cacert" do
-      flexmock(Chef::DataBagItem).should_receive(:load)
-        .and_return({
-          'certificate' => 'test-cert-text',
-          'cacert' => 'test-cacert-text'
+      # Mocking search() looking for the certificate databag item
+      search_query = "id:729c42d574be013c27ee3600bd87018825792c9d15057d2b0b8833796aa09e19"
+      search = flexmock('search') do |m|
+        m.should_receive(:search)
+          .with(:certificates, search_query, FlexMock.any)
+          .and_yield({
+             'certificate' => 'test-cert-text',
+             'cacert' => 'test-cacert-text'
         })
+      end
+      flexmock(Chef::Search::Query).should_receive(:new).and_return(search)
 
       # mocking File.size for the specific files the provider
       # expects - here, the key exists
@@ -310,10 +320,14 @@ describe 'x509_certificate', :type => :provider do
     }
 
     it "should not touch cert or key" do
-      flexmock(Chef::DataBagItem).should_receive(:load)
-        .and_return({
-          'certificate' => 'test-cert-text'
-        })
+      # Mocking search() looking for the certificate databag item
+      search_query = "id:729c42d574be013c27ee3600bd87018825792c9d15057d2b0b8833796aa09e19"
+      search = flexmock('search') do |m|
+        m.should_receive(:search)
+          .with(:certificates, search_query, FlexMock.any)
+          .and_yield( {'certificate' => 'test-cert-text'} )
+      end
+      flexmock(Chef::Search::Query).should_receive(:new).and_return(search)
 
       # mocking File.size for the specific files the provider
       # expects - here, the key is present
@@ -372,10 +386,14 @@ describe 'x509_certificate', :type => :provider do
     }
 
     it "should not touch cert or key" do
-      flexmock(Chef::DataBagItem).should_receive(:load)
-        .and_return({
-          'certificate' => 'test-cert-text'
-        })
+      # Mocking search() looking for the certificate databag item
+      search_query = "id:729c42d574be013c27ee3600bd87018825792c9d15057d2b0b8833796aa09e19"
+      search = flexmock('search') do |m|
+        m.should_receive(:search)
+          .with(:certificates, search_query, FlexMock.any)
+          .and_yield( {'certificate' => 'test-cert-text'} )
+      end
+      flexmock(Chef::Search::Query).should_receive(:new).and_return(search)
 
       # mocking File.size for the specific files the provider
       # expects - here, the key is missing


### PR DESCRIPTION
The x509_certificate resource currently logs a number of messages at INFO and WARN level, on every run.  This PR changes the way data bag items are loaded (avoiding two messages), and reopens previously defined resources to avoid warnings related to CHEF-3694.
