### PR TITLE
chef-ssl crashes on wonky data

### DIFF
--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -65,6 +65,7 @@ module ChefSSL
         nodes = Spice.nodes("csr_outbox_*")
       end
       nodes.each do |node|
+        next if node.normal['csr_outbox'].nil?
         node.normal['csr_outbox'].each do |id, data|
           next if data['csr'].nil? # XXX warn, raise?
           yield Request.new(node.name, data)


### PR DESCRIPTION
One line fix to prevent it from crashing on bad data. 
