### PR TITLE
Add not_before and not_after to the data bag.

### DIFF
--- a/client-gem/lib/chef-ssl/client/issued_certificate.rb
+++ b/client-gem/lib/chef-ssl/client/issued_certificate.rb
@@ -48,6 +48,8 @@ module ChefSSL
           :key => @req.key,
           :type => @req.type,
           :date => Time.now.to_s,
+          :not_after => @cert.not_after,
+          :not_before => @cert.not_before,
           :host => @req.host,
           :certificate => @cert.to_pem
         }


### PR DESCRIPTION
This could make it easier to search for certs nearing their end-of-life.
