### PR TITLE
Merge the ca-cert to the cert

### DIFF
--- a/providers/certificate.rb
+++ b/providers/certificate.rb
@@ -51,7 +51,11 @@ action :create do
       if x509_verify_key_cert_match(::File.read(new_resource.key), certbag['certificate'])
         Chef::Log.info("installing certificate #{new_resource.name} (id #{cert_id})")
         f = resource("file[#{new_resource.certificate}]")
-        f.content certbag['certificate']
+        if new_resource.joincachain && certbag['cacert']
+          f.content certbag['certificate'] + certbag['cacert']
+        else
+          f.content certbag['certificate']
+        end
         f.action :create
         
         if new_resource.cacertificate && certbag['cacert']

--- a/resources/certificate.rb
+++ b/resources/certificate.rb
@@ -18,3 +18,5 @@ attribute :group, :kind_of => String, :default => 'root'
 attribute :cacertificate, :kind_of => String
 attribute :certificate,   :kind_of => String, :required => true
 attribute :key,           :kind_of => String, :required => true
+
+attribute :joincachain,   :equal_to => [true, false], :default => false


### PR DESCRIPTION
Add the ca-certificate to the cert to get at least a start of an cachain.

This is needed when nginx (for example) is to use the cert.
