### PR TITLE
Switching to secure rubygems.org source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # testing-framework deps
 gem 'chef', '10.14.2'

--- a/client-gem/Gemfile
+++ b/client-gem/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
When running bundle on the client-gem Gemfile, a deprecation warning was
being shown.

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
```

Switching the source line fixes that warning.
