### PR TITLE
Implement support to revoke certificates and generate CRL's

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 Changelog for the 'x509' cookbook, and the 'chef-ssl-client' gem.
 
+Version 1.2.0
+ 
+ * Add support for the revoke and gencrl commands. (Michael Hart)
+
 Version 1.1.0
 
  * Switch to secure rubygems source to avoid deprecation warning from

--- a/README.md
+++ b/README.md
@@ -98,8 +98,20 @@ Retrieve the CRL for a CA. The resource name specified must match the
 DN of the CA but the format wreaks havoc on chef searches:
 
     x509_crl "My-CA" do
-      path "/etc/public/My-CA.crl.pem"
+      action :create
     end
+
+If you want you specify a path for the CRL file. However due to some oddities with
+OpenVPN (and thus likely openssl) that are not fully documented, to function properly the
+CRL must be saved as /etc/ssl/certs/<hash>.r0 where the hash is that of the CA. The x509_crl
+provider by default does the hash generation and puts it in the correct place. If you need
+to find the the file to specify in another recipy, use the x509_get_crl_path() method 
+(defined in x509/libraries/x509.rb) and it will return the fully qualified path to the CRL. For 
+example:
+
+    crl_path = x509_get_crl_path("My-CA")
+
+
 
 Signing Client
 ==============

--- a/client-gem/Gemfile.lock
+++ b/client-gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chef-ssl-client (1.1.0)
+    chef-ssl-client (1.2.0)
       activesupport (>= 3.1.0)
       chef (>= 0.10.0)
       commander (~> 4.1.0)
@@ -53,7 +53,7 @@ GEM
     mixlib-cli (1.3.0)
     mixlib-config (2.0.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.2.0)
+    mixlib-shellout (1.3.0)
     multi_json (1.3.7)
     multipart-post (1.2.0)
     net-ssh (2.7.0)

--- a/client-gem/lib/chef-ssl/client.rb
+++ b/client-gem/lib/chef-ssl/client.rb
@@ -7,6 +7,9 @@ require 'active_support/hash_with_indifferent_access'
 require 'chef/knife'
 require 'chef/config'
 require 'chef/node'
+require 'date'
+require 'open3'
+require 'fileutils'
 
 require 'chef-ssl/client/version'
 require 'chef-ssl/client/request'
@@ -15,7 +18,7 @@ require 'chef-ssl/client/issued_certificate'
 
 module ChefSSL
   class Client
-
+    
     def initialize
       Chef::Knife.new.tap do |knife|
         # Set the log-level, knife style. This equals :error level
@@ -86,5 +89,187 @@ module ChefSSL
       end
     end
 
+    # Revoke a certificate for the given hostname. This doesn't actually quite revoke
+    # it, but instead moves the cert from the _certificates_ databag and moves it
+    # to the _revoked_certificates_ databag, adding trhee attributes, namely _revoked_, 
+    # _revoked_date_ and _serial_. _revoked_ is set to false, to be later changed when the cert is
+    # really revoked by the gencrl command. _serial_ can be used to generate a list of revoked
+    # ceritificates such as for OpenVPN >= 2.3.0
+    #
+    # This seems like a hack but allows for revocation by automated scripts, without 
+    # requiring the CA passphrase. 
+    #
+    def revoke_certificate(hostname)
+      now = DateTime.now()
+      revoke_params = {
+        :revoked => false,
+        :revoked_date => now.strftime("%Y-%m-%d %H:%M:%S %z"),
+        :serial => nil
+      }
+      num_revoked = 0
+
+      #ensure the revoked data bag exists
+      revoked_data_bag = get_or_create_databag(IssuedCertificate::REVOKED_DATABAG)
+
+      #spice has a weird problem with looping through data bag items so we do it this way.
+      raw_items = Spice.get("/data/" + IssuedCertificate::DATABAG)
+      raw_items.each do |raw_item|
+        cert_item = Spice.data_bag_item(IssuedCertificate::DATABAG, raw_item[0])
+        if cert_item['host'] == hostname
+          begin
+            #try create the cert in the revoked data bag
+            revoke_item = Spice.create_data_bag_item(IssuedCertificate::REVOKED_DATABAG, cert_item.attrs)
+          rescue Spice::Error::Conflict
+            #already exists can't deal with it.
+            say "Certificate for hostname '" + hostname + "' has already been revoked."
+            next
+          end
+
+          #get serial 
+          revoke_params['serial'] = get_serial(revoke_item['certificate'])
+
+          #add our new params and update
+          revoke_item.attrs.merge!(revoke_params)
+          Spice.update_data_bag_item(IssuedCertificate::REVOKED_DATABAG, revoke_item['id'], revoke_item.attrs)
+
+          #finally delete the item we're looking at.
+          Spice.delete_data_bag_item(IssuedCertificate::DATABAG, cert_item['id'])
+
+          num_revoked += 1
+        end
+      end
+      say "Revoked " + num_revoked.to_s + " certificates for '" + hostname + "'."
+    end
+
+    # private helper to get serial from a certificate
+    def get_serial(certificate_string)
+      certificate = OpenSSL::X509::Certificate.new(certificate_string)
+      return certificate.serial.to_s
+    end
+    
+    #private helper to get a data bag or create it if needed 
+    def get_or_create_databag(name)
+      begin
+        data_bag = Spice.data_bag(name)
+      rescue Spice::Error::NotFound
+        data_bag = Spice.create_data_bag(name)
+      end
+      return data_bag
+    end
+    
+    #private helper function, takes a CRL file (pem format) and uploads it to the certificate_revocation_list data bag
+    #using the CA 
+    def upload_crl(crlfilename, authority) 
+      now = DateTime.now()
+      crl_data_bag = get_or_create_databag(SigningAuthority::CRL_DATABAG)
+      #ID must match: /^[\-[:alnum:]_]+$/ so ID is hash of the dn
+      name_sha = Digest::SHA256.new << authority.dn
+      crl_id = name_sha.to_s
+      crl_params = {
+        :id => crl_id, 
+        :crl => IO.read(crlfilename),
+        :dn => authority.dn,
+        :updated_date => now.strftime("%Y-%m-%d %H:%M:%S %z")
+      }
+      begin
+        #try create the cert in the revoked data bag
+        crl_item = Spice.create_data_bag_item(SigningAuthority::CRL_DATABAG, crl_params)
+      rescue Spice::Error::Conflict
+        #already exists, update it
+        crl_item = Spice.data_bag_item(SigningAuthority::CRL_DATABAG, crl_id)
+        crl_item.attrs.merge!(crl_params)
+        Spice.update_data_bag_item(SigningAuthority::CRL_DATABAG, crl_id, crl_item.attrs)
+      end 
+    end
+    
+    # Generate a CRL, but first really revoke any certificates in the 
+    # _revoked_certificates_ data bag that have _revoked_ set to false. Both of these
+    # operations require the passphrase. Logic is thus:
+    #
+    # * For each data bag item with revoked:false
+    #   * grab cert and write to file (for openssl)
+    #   * run _openssl ca -revoke_ against the file
+    #   * update data bag item with revoked:true and the revoked_date_v2 date.
+    # * Generate the new CRL file regardless if we revoked anything or not. This is on purpose.
+    # * Upload the CRL to the certificate_revocation_list data bag
+    #
+    # The SigningAuthority is passed here but not actually used except for getting the 
+    # DN from the key. Since there is no OpenSSL API to revoke the cert or generate a CRL
+    # we have to # call out to openssl proper to do so.
+    def generate_crl(passphrase, capath, caconfig, crlfilename, revoked_path, authority)
+      #look through the revoked data bag and get items that have revoked:false set
+      num_revoked = 0
+
+      now = DateTime.now()
+      revoked_attributes = {
+        :revoked => true,
+        :revoked_date_v2 => now.strftime("%Y-%m-%d %H:%M:%S %z")
+      }
+
+      #loop through data bag items, using get and then retrieval due to spice issue
+      raw_items = Spice.get("/data/" + IssuedCertificate::REVOKED_DATABAG)
+      raw_items.each do |raw_item|
+        revoked_item = Spice.data_bag_item(IssuedCertificate::REVOKED_DATABAG, raw_item[0])
+        if revoked_item['revoked'] != true
+          #1. Write out cert into file from 'certificate' attribute
+          cert_file = write_cert_to_file(revoked_item, revoked_path)
+
+          #2. Run openssl against file.
+          #Example: openssl ca -revoke cert.pem -config testca.conf  -key test123
+          exec_openssl_ca(['-revoke', cert_file, '-config', caconfig, '-key', passphrase])
+
+          #4. Update the data bag item
+          revoked_item.attrs.merge!(revoked_attributes)
+          Spice.update_data_bag_item(IssuedCertificate::REVOKED_DATABAG, revoked_item['id'], revoked_item.attrs)
+          num_revoked += 1
+        end
+      end
+
+      #generate CRL file
+      #Example: openssl ca -gencrl -config conf/testca.conf -key testing -out crl.pem
+      exec_openssl_ca(['-gencrl', '-config', caconfig, '-key', passphrase, '-out', crlfilename])
+      say "Generated CRL '" + crlfilename + "'."
+
+      #upload CRL to data bag
+      upload_crl(crlfilename, authority)
+      say "Uploaded CRL to chef."
+    end
+      
+    # Private helper method used to write a certificate to a file.
+    def write_cert_to_file(revoked_item, revoked_path)
+      dirname = File.dirname(revoked_path)
+      unless File.directory?(revoked_path)
+        FileUtils.mkdir_p(revoked_path)
+      end
+      filename = revoked_path + "/" + revoked_item['host'] + ".pem"
+      File.open(filename, 'w') { |file| file.write(revoked_item['certificate']) }
+      return filename
+    end
+
+    # Private helper method to run "openssl ca" commands. 
+   def exec_openssl_ca(args)
+      #args is an array of options 
+      cmd = "openssl ca " + args.join(" ")
+      status = 0
+      err = ''
+      out = ''
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+        stderr.each { |line| err += line }
+        stdout.each { |line| out += line }
+        status = wait_thr.value
+      end
+      if status.exitstatus != 0
+        #something bad happened
+        mssg = "Error running command '" + cmd + ": " 
+        if not out.nil?
+          mssg += out.to_s
+        end
+        if not err.nil?
+          mssg += " " + err.to_s
+        end
+        raise mssg
+      end
+    end
   end
 end
+

--- a/client-gem/lib/chef-ssl/client/issued_certificate.rb
+++ b/client-gem/lib/chef-ssl/client/issued_certificate.rb
@@ -3,8 +3,10 @@ module ChefSSL
     class CertSaveFailed < StandardError; end
 
     class IssuedCertificate
+      attr_accessor :req
 
       DATABAG = "certificates"
+      REVOKED_DATABAG = "revoked_certificates"
 
       def initialize(req, cert, ca=nil)
         @ca = ca

--- a/client-gem/lib/chef-ssl/client/request.rb
+++ b/client-gem/lib/chef-ssl/client/request.rb
@@ -3,6 +3,7 @@ module ChefSSL
     class Request
 
       attr_reader :host, :csr, :type, :ca, :id, :name, :key, :days
+      attr_writer :id, :ca, :host
 
       def initialize(host, data, csr=nil)
         @host = host

--- a/client-gem/lib/chef-ssl/client/signing_authority.rb
+++ b/client-gem/lib/chef-ssl/client/signing_authority.rb
@@ -1,6 +1,10 @@
+require 'digest/sha2'
+
 module ChefSSL
   class Client
     class SigningAuthority
+
+      CRL_DATABAG = "certificate_revocation_list" 
 
       def self.load(options)
         ca = EaSSL::CertificateAuthority.load(

--- a/client-gem/lib/chef-ssl/client/version.rb
+++ b/client-gem/lib/chef-ssl/client/version.rb
@@ -1,5 +1,5 @@
 module ChefSSL
   class Client
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/client-gem/lib/chef-ssl/command.rb
+++ b/client-gem/lib/chef-ssl/command.rb
@@ -309,6 +309,7 @@ command :gencrl do |c|
   c.example "Generate the CRL", "chef-ssl gencrl --ca-path=/opt/myca --ca-config=conf/myca.conf --crlfilename=mycrl.pem"
   c.option "--ca-path=STRING", String, "the path to the signing CA"
   c.option "--ca-config=STRING", String, "the path to the config file of your CA. Can be absolute or relative to ca-path"
+  c.option "--ca-name=STRING", String, "name of the CA saved as 'ca_name' attribute in the crl data bag. Useful for searches, defaults to the DN"
   c.option "--crlfilename=STRING", String, "name of CRL file to generate, default is crl.pem. Can be absolute or relative to ca-path"
   c.option "--revoked-path=STRING", String, "directory where revoked certificates should be placed, default is ./revoked relative to the ca-path"
   c.action do |args, options|
@@ -322,6 +323,7 @@ command :gencrl do |c|
       :password => passphrase,
       :path => options.ca_path
     )
-    client.generate_crl(passphrase, options.ca_path, options.ca_config, options.crlfilename, options.revoked_path, authority)
+    options.default :ca_name => authority.dn
+    client.generate_crl(passphrase, options.ca_path, options.ca_config, options.crlfilename, options.revoked_path, authority, ca_name)
   end
 end

--- a/client-gem/lib/chef-ssl/command.rb
+++ b/client-gem/lib/chef-ssl/command.rb
@@ -324,6 +324,6 @@ command :gencrl do |c|
       :path => options.ca_path
     )
     options.default :ca_name => authority.dn
-    client.generate_crl(passphrase, options.ca_path, options.ca_config, options.crlfilename, options.revoked_path, authority, ca_name)
+    client.generate_crl(passphrase, options.ca_path, options.ca_config, options.crlfilename, options.revoked_path, authority, options.ca_name)
   end
 end

--- a/client-gem/lib/chef-ssl/command.rb
+++ b/client-gem/lib/chef-ssl/command.rb
@@ -295,8 +295,6 @@ command :revoke do |c|
     if args.size < 1
       say "Error, specify a HOSTNAME to revoke."
     else 
-      #get authority, don't load it because we don't need or 
-      #want the passphrase
       client = ChefSSL::Client.new
       args.each do |host|
         client.revoke_certificate(host)

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -49,3 +49,13 @@ def urlsafe_encode64(bin)
     [bin].pack("m0").chomp("\n").tr("+/", "-_")
   end
 end
+
+#return an array of revoked certificate serial numbers
+def x509_revoked_serials()
+  serials = Array.new()
+  certs = search(:revoked_certificates)
+  certs.each do |cert|
+    serials << cert['serial']
+  end
+  return serials
+end

--- a/libraries/x509.rb
+++ b/libraries/x509.rb
@@ -59,3 +59,21 @@ def x509_revoked_serials()
   end
   return serials
 end
+
+#private get a crl item for the CA specified from the data bag
+def x509_get_crl(caname)
+  # search for CRL in one of its issued certificate databags
+  items = search('certificate_revocation_list', "ca:#{caname}") 
+  if items.nil? or items.size == 0
+    raise "Could not find CRL for CA '#{caname}'"
+  elsif items.size > 1
+    raise "Found more than one CRL for CA '#{caname}', there can only be one."
+  end
+  return items[0]
+end
+
+#for a caname in the certificate_revocation_list data bag, return the path to the file
+def x509_get_crl_path(caname) 
+  item = x509_get_crl(caname)
+  return "/etc/ssl/certs/#{item['hash']}.r0"  
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "candrews@venda.com"
 license          "Apache"
 description      "Deploy a Chef-managed Certificate Authority"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.0"
+version          "1.2.0"
 
 depends 'vt-gpg'

--- a/providers/crl.rb
+++ b/providers/crl.rb
@@ -1,0 +1,14 @@
+
+action :create do
+  # search for CRL in one of its issued certificate databags
+  items = search('certificate_revocation_list', "ca:#{new_resource.ca}") do |item|
+    file new_resource.path do
+      content item['crl']
+      action :create
+      owner new_resource.owner
+      group new_resource.group
+      mode new_resource.mode
+    end
+    new_resource.updated_by_last_action(true)
+  end
+end

--- a/providers/crl.rb
+++ b/providers/crl.rb
@@ -1,14 +1,18 @@
-
 action :create do
-  # search for CRL in one of its issued certificate databags
-  items = search('certificate_revocation_list', "ca:#{new_resource.ca}") do |item|
-    file new_resource.path do
-      content item['crl']
-      action :create
-      owner new_resource.owner
-      group new_resource.group
-      mode new_resource.mode
-    end
-    new_resource.updated_by_last_action(true)
+  item = x509_get_crl(new_resource.ca)
+  if not new_resource.filename.nil?
+    crl_file = new_resource.filename
+  else
+    crl_file = "/etc/ssl/certs/#{item['hash']}.r0"
   end
+  Chef::Log.info("MDH: filename: #{crl_file}")
+  new_resource.filename = crl_file
+  file crl_file do
+    content item['crl']
+    action :create
+    owner new_resource.owner
+    group new_resource.group
+    mode new_resource.mode
+  end
+  new_resource.updated_by_last_action(true)
 end

--- a/resources/crl.rb
+++ b/resources/crl.rb
@@ -6,8 +6,9 @@ def initialize(*args)
 end
 
 attribute :ca, :kind_of => String, :name_attribute => true
-attribute :path, :kind_of => String, :required => true
-
+attribute :filename, :kind_of => String, :default => nil
 attribute :owner, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
 attribute :mode, :kind_of => String, :default => '0644'
+
+attr_accessor :filename

--- a/resources/crl.rb
+++ b/resources/crl.rb
@@ -1,0 +1,13 @@
+actions :create
+
+def initialize(*args)
+  super
+  @action = :create
+end
+
+attribute :ca, :kind_of => String, :name_attribute => true
+attribute :path, :kind_of => String, :required => true
+
+attribute :owner, :kind_of => String, :default => 'root'
+attribute :group, :kind_of => String, :default => 'root'
+attribute :mode, :kind_of => String, :default => '0644'


### PR DESCRIPTION
Add "chef-ssl revoke" and "chef-ssl gencrl" commands to revoke and generate CRL's. This was thoroughly tested in real life, revoking certificates for the Heartbleed mess. This addresses issue https://github.com/VendaTech/chef-cookbook-ssl/issues/10. Also updated the README, bumped version to 1.2.0, added a --save option to the issue command, added two new data bags 'revoked_certificates' and 'certificate_revocation_list', among other things.

Apologies for the many commits, I messed up with one account and can't fix it short of creating a new branch and pull request. If you prefer that I can go through that process.
